### PR TITLE
Fix cyndilib support on Windows

### DIFF
--- a/pip_importer.py
+++ b/pip_importer.py
@@ -78,9 +78,13 @@ def check_module(package):
 
 
 def get_package_show(package):
+    import os
+    from sys import platform
+
     try:
+        enc = os.device_encoding(1) if platform == "win32" else "utf-8"
         cmd = [PYPATH, "-m", "pip", "show",  package.name]
-        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding=enc)
         store_package_show(package, result)
     except:
         pass


### PR DESCRIPTION
Python on Windows uses the console encoding for output, which is not UTF-8 by default. This causes the check package test to fail because the description for cyndilib on PyPI has a registered trademark symbol, which is encoded differently depending on your locale on Windows.