### PR TITLE
Update SpoutGL version in __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -37,7 +37,7 @@ def register():
 
     # then add the required packages
     if platform.system() == "Windows":
-        pip_importer.add_package(pip_importer.Package("SpoutGL", version="==0.1.0", custom_module="SpoutGL"))
+        pip_importer.add_package(pip_importer.Package("SpoutGL", version="==0.1.1", custom_module="SpoutGL"))
 
     if platform.system() == "Darwin":  
         pip_importer.add_package(pip_importer.Package("syphon-python", version="==0.1.0", custom_module="syphon"))


### PR DESCRIPTION
Update the SpoutGL version from "0.1.0" to "0.1.1" so that it works with Python313 that ships with Blender 5.1.2